### PR TITLE
Adding suppot for basepath and display name for deploy tool

### DIFF
--- a/ProjectTemplates/Apigee Proxy/deploy.py
+++ b/ProjectTemplates/Apigee Proxy/deploy.py
@@ -38,7 +38,7 @@ def validateAndDeploy(data):
 			print("INFO: No Password specified in 'deploy_vars.json' - trying to access Mac keychain")
 			try:
 				import keyring
-				os.environ['pass'] = keyring.get_password(os.environ['org'],os.environ['user'])
+				os.environ['pass'] = keyring.get_password(os.environ['org'],os.environ['user']) or ""
 				if not os.environ['pass']:
 					print("ERROR: Maintain password either in 'deploy_vars.json' or in Mac Keychain | Deploy suspended")
 				else:

--- a/ProjectTemplates/Apigee Proxy/deploy.py
+++ b/ProjectTemplates/Apigee Proxy/deploy.py
@@ -24,7 +24,10 @@ def validateAndDeploy(data):
 		os.environ['uri'] = ""
 	else:
 		os.environ['uri'] = data["uri"]
-
+	if data['basepath']:
+		os.environ['basepath']=data['basepath']
+	if data['displayname']:
+		os.environ['displayname']=data['displayname']
 
 	if data["env"] and data["org"] and data["username"]:
 		os.environ['user'] = data["username"]
@@ -59,6 +62,10 @@ def deployApi():
 		command = "/usr/local/bin/apigeetool deployproxy -n $proxy -o $org -e $env -u $user -p $pass -d $dir -l $uri"
 	else:
 		command = "/usr/local/bin/apigeetool deployproxy -n $proxy -o $org -e $env -u $user -p $pass -d $dir"
+	if os.environ['displayname']:
+		command +=" -n $displayname"
+	if os.environ['basepath']:
+		command+=" -b $basepath"
 
 	print("INFO: This takes a while - anywhere from 30 - 50 secs on Apigee cloud (psst:'ctrl+c' will cancel deploying)")
 


### PR DESCRIPTION
added support for more control over proxy name and base path from deploy tool:
jsut add fields to the deploy_vars file
{
    "org":"MY ORG",
    "env":"MY ENV",
    "username":"username",
    "password":"", 
    "uri":"",
    "basepath":"base path to use",
    "displayname":"display name"
}
